### PR TITLE
Hotfix: Wrong price on export to odoo

### DIFF
--- a/frepple/controllers/inbound.py
+++ b/frepple/controllers/inbound.py
@@ -162,6 +162,8 @@ class importer(object):
                                         product.product_tmpl_id.id,
                                     ),
                                     ("min_qty", "<=", quantity),
+                                    ("date_end", ">=", datetime.datetime.now()),
+                                    ("date_start", "<=", datetime.datetime.now())
                                 ],
                                 limit=1,
                                 order="min_qty desc",

--- a/frepple/controllers/inbound.py
+++ b/frepple/controllers/inbound.py
@@ -162,8 +162,8 @@ class importer(object):
                                         product.product_tmpl_id.id,
                                     ),
                                     ("min_qty", "<=", quantity),
-                                    ("date_end", ">=", datetime.datetime.now()),
-                                    ("date_start", "<=", datetime.datetime.now())
+                                    ("date_end", ">=", datetime.now()),
+                                    ("date_start", "<=", datetime.now())
                                 ],
                                 limit=1,
                                 order="min_qty desc",


### PR DESCRIPTION
Dag FrePPLe,

we zijn er achter gekomen dat wanneer we een FrePPLe export aar odoo doen, hij soms de foute prijs selecteerd.
Ik neem aan dat dit komt doordat we de eerste de beste supplierinfo selecteren, en niet uitfilteren op start en end datum.

Kan je dit nog even verifiëren?

Groeten,
Machiels Kyan